### PR TITLE
add yaml support, requests init options, adhoc redcap options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cappy
+# cappy v1.1.0
 The Redcap API library that you build yourself.
 
 ## Ideology ##

--- a/cappy/cap.py
+++ b/cappy/cap.py
@@ -1,34 +1,41 @@
-import json
 import copy
 
 import requests as req
+import yaml
 
 import cappy.utils as utils
 
 class API(object):
     """
     The only class in the library. Dynamically adds methods to itself
-    on initialization from a json file in the "versions" directory
+    on initialization from a json or yaml file in the "versions" directory
     """
 
-    def __init__(self, token, endpoint, version_file):
+    def __init__(self, token, endpoint, version_file, requests_options={}):
         """
         Given:
         - a token for a project
         - an endpoint to query
         - a filename for a version file
+        - an optional dictionary of options for requests
 
         Result:
         An instance of API that has each top level key as a method.
         These methods will return a requests response object when called
         and will generally do what you expect when calling them with and
         without arguments. Any variadic fields are passed as keyword parameters
+
+        The requests options will be applied to all calls made with the
+        auto generated API functions
         """
         version_path = utils.path_for_version(version_file)
+        self.requests_options = requests_options
         with open(version_path, 'r') as api_def:
-            self.api_definition = json.loads(api_def.read())
+            version_data = yaml.load(api_def.read())
+            self.api_definition = version_data.get('api_def') or version_data
         for key in self.api_definition:
             setattr(self, key, self._redcap_call_from_def(token, endpoint, key))
+
 
     def _redcap_call_from_def(self, token, endpoint, key):
         """
@@ -47,22 +54,46 @@ class API(object):
             This will call the redcap api with the form arguments filled in correctly
             """
             call_definition = self.api_definition[key]
-            data_copy = copy.copy(call_definition)
-            body = self._build_post_body(token, data, data_copy, **kwargs)
-            res = req.post(endpoint, body)
-            return self._enhance_response(res, key, copy.copy(call_definition))
+            call_def_copy = copy.copy(call_definition)
+            body = self._build_post_body(token, data, call_def_copy, **kwargs)
+            res = req.post(endpoint, body, **self.requests_options)
+            return self._enhance_response(res, key, copy.copy(call_definition), kwargs, body)
         return run_call
 
-    def _build_post_body(self, token, data, post_body, **kwargs):
+    def _build_post_body(self, token, data, post_body_template, **kwargs):
         """
         Constructs a post body for a redcap api call based on what is in
-        the versioned api definition json.
+        the versioned api definition json, and optionally in the
+        'adhoc_redcap_options' kwarg
         """
-        post_body['token'] = token
+        post_copy = copy.copy(post_body_template)
+        post_copy['token'] = token
         if data:
-            post_body['data'] = data
-        post_copy = copy.copy(post_body)
-        for key in post_body:
+            post_copy['data'] = data
+            # We dont want to allow readonly methods to write
+            if not post_body_template['data']:
+                del post_copy['data']
+
+        # Usually you should edit the version file to add another option to a call
+        # to redcap. There are times that this takes a prohibitive amount of time,
+        # so when calling a API function one can pass key value pairs of options
+        # to add by passing 'adhoc_redcap_options' as a kwarg to the function
+        # any iterable keys passed in this manner need to have their contents
+        # passed the usual way as a kwarg
+        for key, val in kwargs.items():
+            if key == 'adhoc_redcap_options':
+                for k, v in val.items():
+                    # we done want people to make readonly functions write
+                    if not k == 'data':
+                        # if we have an iterable
+                        if type(v) == type([]):
+                            post_body_template[k] = []
+                        # we just have some option like rawOrLabel
+                        else:
+                            post_copy[k] = v
+
+        # add iterable things to the post_copy which will be POSTed to redcap
+        for key in post_body_template:
             if type(kwargs.get(key)) == type([]):
                 iterable_name = key
                 post_copy = self._add_iterable(kwargs[key], iterable_name, post_copy)
@@ -81,15 +112,19 @@ class API(object):
             post_body['{}[{}]'.format(name, index)] = item
         return post_body
 
-    def _enhance_response(self, response, call_name, call_def):
+    def _enhance_response(self, response, call_name, call_def, kwargs, body):
         """
         This function exists to expose to the end user more information about
         the way in which the request was called. For instance, they may want
         to know what the format of the file returned is.
         """
+        if body.get('data'):
+            del body['data']
         response.cappy_data = {
-            "call_name": call_name,
-            "file_format": call_def.get("format"),
-            "error_format": call_def.get("returnFormat"),
+            'call_name': call_name,
+            'file_format': call_def.get('format'),
+            'error_format': call_def.get('returnFormat'),
+            'kwargs_passed': kwargs,
+            'post_body_minus_data': body
         }
         return response

--- a/cappy/examples/test.py
+++ b/cappy/examples/test.py
@@ -1,0 +1,33 @@
+import json
+
+from cappy import API
+
+redcap_token = 'F53EA8B9D58456B722945F4B274E6B4C'
+redcap_api_endpoint = 'http://redi2.dev/redcap/api/'
+cappy_version = 'lineman.json'
+
+api = API(redcap_token, redcap_api_endpoint, cappy_version)
+
+# only gets the records for subjects with unique_field 1 and 2
+res = api.export_records(records=[1,2])
+
+cappy_version = 'master.yaml'
+api = API(redcap_token, redcap_api_endpoint, cappy_version, requests_options={
+    'verify': False,
+    'headers': {
+        'TEST': 'THIS IS A TEST'
+    }
+})
+
+# exports in eav instead of flat
+# resist the urge to use adhoc options
+res = api.export_records(adhoc_redcap_options={
+    'type': 'eav'
+})
+
+# we get back raw requests content
+# print(res.content)
+# cappy gives us more information about what was passed
+print(res.cappy_data)
+# we can alter the requests initialization
+print(res.request.headers.get('TEST'))

--- a/cappy/versions/README.md
+++ b/cappy/versions/README.md
@@ -1,8 +1,8 @@
 # Purpose of these files #
 
-These json files define different ways to produce API instances.
+These yaml and json files define different ways to produce API instances.
 
-Every top level key is a method on the API instance and the object corresponding to that key
+Every top level key or api_def level key is a method on the API instance and the object corresponding to that key
 is the post body that is given when viewed on the API playground screen in RedCap.
 
 Any iterable / list-like argument (i.e. forms, fields) should have an array as its value in the 

--- a/cappy/versions/master.yaml
+++ b/cappy/versions/master.yaml
@@ -1,0 +1,142 @@
+# This cappy file has been tested with redcap 6.16.x and 6.13.0
+# and should be used if you dont have a more specific version file
+
+# read the following link for information about what << means
+# https://web.archive.org/web/20130213112648/http://blog.101ideas.cz/posts/dry-your-yaml-files.html
+
+# WARNING this is the most permissive cappy version file and can WIPE
+# the redcap completely
+helpers:
+  export: &export
+    token: ''
+  import: &import
+    token: ''
+    data: true
+  # some redcap functions require an action key value pair
+  # empirically this is used to delineate between deletes and imports
+  actions:
+    import: &action_import
+      action: import
+    delete: &action_delete
+      action: delete
+  iterables: &iters
+    forms: []
+    fields: []
+  formats:
+    json: &json
+      format: json
+      returnFormat: json
+    csv: &csv
+      format: csv
+      returnFormat: csv
+    csv_in_json_error: &csv_in_json_error
+      format: csv
+      returnFormat: json
+  contents:
+    - &project project
+    - &event event
+    - &arm arm
+    - &metadata metadata
+    - &record record
+    - &instrument instrument
+    - &instrument_event formEventMapping
+  
+api_def:
+  # project info
+  export_project_info:
+    <<: *export
+    <<: *json
+    content: *project
+  import_project_info:
+    <<: *import
+    <<: *json
+    content: *project
+
+  # arms
+  export_arms:
+    <<: *export
+    <<: *json
+    content: *arm
+  import_arms:
+    <<: *import
+    <<: *json
+    <<: *action_import
+    content: *arm
+
+  # events
+  export_events:
+    <<: *export
+    <<: *json
+    content: *event
+  import_events:
+    <<: *import
+    <<: *json
+    <<: *action_import
+    content: *event
+  delete_events:
+    token: ''
+    events: []
+    <<: *json
+    <<: *action_delete
+    content: *event
+
+  # instrument_event_mapping
+  export_instrument_event_mapping:
+    <<: *export
+    <<: *json
+    content: *instrument_event
+  import_instrument_event_mapping:
+    <<: *import
+    <<: *json
+    content: *instrument_event
+
+  # instruments
+  export_instruments:
+    <<: *export
+    <<: *json
+    content: *instrument
+
+  # metadata
+  # It has been observed that the only working format
+  # for metadata imports is csv so that is the default here
+  export_metadata:
+    <<: *export
+    <<: *csv_in_json_error
+    <<: *iters
+    content: *metadata
+  import_metadata:
+    <<: *import
+    <<: *csv_in_json_error
+    content: *metadata
+  export_metadata_json: 
+    <<: *export
+    <<: *json
+    <<: *iters
+    content: *metadata
+  import_metadata_json:
+    <<: *import
+    <<: *json
+    content: *metadata
+
+  # records
+  export_records:
+    <<: *export
+    <<: *json
+    <<: *iters
+    content: *record
+    # events takes a list of unique_event_name
+    events: []
+    # this records iterable is for getting the records pretaining
+    # to a specific unique_field subject
+    records: []
+  import_records: &import_records
+    <<: *import
+    <<: *json
+    content: *record
+    returnContent: ids
+    type: flat
+    overwriteBehavior: normal
+  import_records_overwrite:
+    <<: *import_records
+    overwriteBehavior: overwrite
+  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
-appdirs==1.4.0
+appdirs==1.4.3
+certifi==2017.4.17
+chardet==3.0.4
+idna==2.5
 packaging==16.8
-pyparsing==2.1.10
-requests==2.13.0
+pyparsing==2.2.0
+PyYAML==3.12
+requests==2.18.1
 six==1.10.0
+urllib3==1.21.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='cappy',
-      version='1.0.0',
+      version='1.1.0',
       description='The redcap api you build yourself',
       url='http://github.com/pfwhite/cappy',
       author='Patrick White',

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='cappy',
       license='MIT',
       packages=['cappy'],
       include_package_data=True,
-      install_requires=['requests'],
+      install_requires=['requests', 'pyyaml'],
       zip_safe=False)


### PR DESCRIPTION
This commit adds a lot of quaility of life features. Yaml versions are
easier to handle, but we don't break the existing json versions. Also
requests sometimes needs particular options to make it work a certain
way dependent on the network. Adhoc redcap and master.yaml version
added to facilitate most use cases